### PR TITLE
Add haml as a development dependency

### DIFF
--- a/styleguide-api.gemspec
+++ b/styleguide-api.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"
+  spec.add_development_dependency "haml"
   spec.add_development_dependency "heredoc_unindent"
 end


### PR DESCRIPTION
Haml is used in the tests, so it needs to be installed.

Without this, I cannot run tests with `bundle exec rake` because of a Tilt error that haml cannot be found.
