### PR TITLE
Add unknown template exception

### DIFF
--- a/lib/styleguide-api.rb
+++ b/lib/styleguide-api.rb
@@ -10,6 +10,16 @@ module StyleGuideAPI
     attr_accessor :theme
   end
 
+  class UnknownTemplateError < StandardError
+    def initialize(template_name)
+      @template_name = template_name
+    end
+
+    def message
+      "Template '#{@template_name}' is not known."
+    end
+  end
+
   def self.initialize
     @live = false
     @templates = {}
@@ -51,7 +61,9 @@ module StyleGuideAPI
 
   def self.template_for(name)
     @templates[theme][name] if @templates[theme] && @templates[theme][name]
-    template = data[theme]["templates"][name]
+    template = data[theme]["templates"].fetch(name) do
+      fail UnknownTemplateError, name
+    end
     @templates[theme] ||= {}
     @templates[theme][name] = Tilt[template["type"]].new { template["source"] }
   end

--- a/test/render_test.rb
+++ b/test/render_test.rb
@@ -28,6 +28,11 @@ describe StyleGuideAPI do
       HTML
     end
 
+    it "should fail with a helpful error when the template is not known" do
+      assert_raises StyleGuideAPI::UnknownTemplateError do
+        StyleGuideAPI.render("does_not_exist")
+      end
+    end
   end
 
 end


### PR DESCRIPTION
A helpful exception is raised when trying to render an unknown template.

Without this, there is just a "NoMethodError: undefined method `[]' for nil:NilClass".
